### PR TITLE
Interdependent percentage sliders

### DIFF
--- a/src/character/ch_stats.gd
+++ b/src/character/ch_stats.gd
@@ -682,9 +682,15 @@ func get_random_race():
 	return input_handler.weightedrandom(array)
 
 func get_random_sex():
-	if randf()*100 <= input_handler.globalsettings.malechance:
+	var male = input_handler.globalsettings.malechance
+	var male_or_futa = input_handler.globalsettings.futachance
+	if !input_handler.globalsettings.futa:
+		male_or_futa = input_handler.globalsettings.malechance
+
+	var roll = randf()*100
+	if roll <= male:
 		return 'male'
-	elif randf()*100 <= input_handler.globalsettings.futachance && input_handler.globalsettings.futa == true:
+	elif roll <= male_or_futa:
 		return 'futa'
 	else:
 		return 'female'

--- a/src/character/ch_stats.gd
+++ b/src/character/ch_stats.gd
@@ -683,14 +683,14 @@ func get_random_race():
 
 func get_random_sex():
 	var male = input_handler.globalsettings.malechance
-	var male_or_futa = input_handler.globalsettings.futachance
+	var futa = input_handler.globalsettings.futachance
 	if !input_handler.globalsettings.futa:
-		male_or_futa = input_handler.globalsettings.malechance
+		futa = 0
 
 	var roll = randf()*100
 	if roll <= male:
 		return 'male'
-	elif roll <= male_or_futa:
+	elif roll <= male + futa:
 		return 'futa'
 	else:
 		return 'female'

--- a/src/scenes/Options.gd
+++ b/src/scenes/Options.gd
@@ -125,11 +125,15 @@ func update_rate_text() -> void:
 func male_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/malerate.value = value
 	input_handler.globalsettings.malechance = value
+	if $TabContainer/Gameplay/VBoxContainer/futarate.value < value:
+		$TabContainer/Gameplay/VBoxContainer/futarate.value = value
 	update_rate_text()
 
 func futa_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/futarate.value = value
 	input_handler.globalsettings.futachance = value
+	if $TabContainer/Gameplay/VBoxContainer/malerate.value > value:
+		$TabContainer/Gameplay/VBoxContainer/malerate.value = value
 	update_rate_text()
 
 func gameplay_rule(rule):

--- a/src/scenes/Options.gd
+++ b/src/scenes/Options.gd
@@ -67,8 +67,11 @@ func open():
 	$TabContainer/Cheats/EnterCodeMenu.visible = !ResourceScripts.game_progress.cheats_active
 	$TabContainer/Cheats/OpenCheatsMenu.visible = ResourceScripts.game_progress.cheats_active
 	$TabContainer/Cheats/OpenCheatsMenu/CheatsMenu.visible = get_parent().name != "Menu_v2"
-	male_rate_change(input_handler.globalsettings.malechance)
-	futa_rate_change(input_handler.globalsettings.futachance)
+
+	var male = input_handler.globalsettings.malechance
+	var futa = input_handler.globalsettings.futachance
+	male_rate_change(male)
+	futa_rate_change(male + futa)
 	
 	for i in $TabContainer/Audio/VBoxContainer.get_children():
 		i.value = input_handler.globalsettings[i.name+'vol']
@@ -114,26 +117,30 @@ func close():
 # 	variables.set(i,button.pressed)
 
 func update_rate_text() -> void:
-        var male = input_handler.globalsettings.malechance
-        var male_or_futa = input_handler.globalsettings.futachance
-        var futa = male_or_futa - male
-        var female = 100 - male_or_futa
-        var text = "Male: %3d%%  -  Futa: %3d%%  -  Female: %3d%%" % [male, futa, female]
-        $TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
-        $TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
+	var male : int = input_handler.globalsettings.malechance
+	var futa : int = input_handler.globalsettings.futachance
+	var female : int = 100 - (male + futa)
+	var text : String = "Male: %3d%%	 -  Futa: %3d%%	 -  Female: %3d%%" % [male, futa, female]
+	$TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
+	$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
 
 func male_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/malerate.value = value
-	input_handler.globalsettings.malechance = value
+	var delta : int = value - input_handler.globalsettings.malechance
+	input_handler.globalsettings.malechance += delta
 	if $TabContainer/Gameplay/VBoxContainer/futarate.value < value:
 		$TabContainer/Gameplay/VBoxContainer/futarate.value = value
+	else:
+                # take (give) the change from (to) the futa range
+		input_handler.globalsettings.futachance -= delta
 	update_rate_text()
 
 func futa_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/futarate.value = value
-	input_handler.globalsettings.futachance = value
 	if $TabContainer/Gameplay/VBoxContainer/malerate.value > value:
 		$TabContainer/Gameplay/VBoxContainer/malerate.value = value
+	var male = $TabContainer/Gameplay/VBoxContainer/malerate.value
+	input_handler.globalsettings.futachance = value - male
 	update_rate_text()
 
 func gameplay_rule(rule):

--- a/src/scenes/Options.gd
+++ b/src/scenes/Options.gd
@@ -113,17 +113,24 @@ func close():
 # func cheat_toggle(i, button):
 # 	variables.set(i,button.pressed)
 
+func update_rate_text() -> void:
+        var male = input_handler.globalsettings.malechance
+        var male_or_futa = input_handler.globalsettings.futachance
+        var futa = male_or_futa - male
+        var female = 100 - male_or_futa
+        var text = "Male: %3d%%  -  Futa: %3d%%  -  Female: %3d%%" % [male, futa, female]
+        $TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
+        $TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
+
 func male_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/malerate.value = value
 	input_handler.globalsettings.malechance = value
-	var text = 'Male generation chance: ' + str(value) + "%"
-	$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = text
+	update_rate_text()
 
 func futa_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/futarate.value = value
 	input_handler.globalsettings.futachance = value
-	var text = 'Futa generation chance: ' + str(value) + "%"
-	$TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
+	update_rate_text()
 
 func gameplay_rule(rule):
 	input_handler.globalsettings[rule] = get_node("TabContainer/Gameplay/" + rule).pressed

--- a/src/scenes/Options.gd
+++ b/src/scenes/Options.gd
@@ -11,7 +11,7 @@ func _ready():
 	$TabContainer/Graphics/fullscreen.pressed = input_handler.globalsettings.fullscreen
 	$TabContainer/Graphics/factors.pressed = input_handler.globalsettings.factors_as_words
 	$TabContainer/Gameplay/VBoxContainer/malerate.connect("value_changed", self, 'male_rate_change')
-	$TabContainer/Gameplay/VBoxContainer/futarate.connect("value_changed", self, "futa_rate_change")
+	$TabContainer/Gameplay/VBoxContainer/male_and_futa_rate.connect("value_changed", self, "futa_rate_change")
 	
 	$TabContainer/Graphics/factors.connect("pressed", self, "toggle_factors")
 	
@@ -72,7 +72,7 @@ func open():
 	var futa = input_handler.globalsettings.futachance
 	if !input_handler.globalsettings.futa:
 		futa = 0
-	$TabContainer/Gameplay/VBoxContainer/futarate.visible = input_handler.globalsettings.futa
+	$TabContainer/Gameplay/VBoxContainer/male_and_futa_rate.visible = input_handler.globalsettings.futa
 
 	male_rate_change(male)
 	futa_rate_change(male + futa)
@@ -127,27 +127,27 @@ func update_rate_text() -> void:
 	if input_handler.globalsettings.futa:
 		var futa : int = input_handler.globalsettings.futachance
 		var female : int = 100 - (male + futa)
-		text = "Male: %3d%%  -  Futa: %3d%%  -  Female: %3d%%" % [male, futa, female]
-		$TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
-		$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
+		text = "Male: %3d%%  -  Futa: %3d%%  -  Female: %3d%%" \
+			% [male, futa, female]
 	else:
 		var female : int = 100 - male
-		text = "Male: %3d%%  -  Female: %3d%%" % [male, female]
-		$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = text
+		text = "Male: %3d%%  -  Female: %3d%%" \
+			% [male, female]
+	$TabContainer/Gameplay/VBoxContainer/SexRates.text = text
 
 func male_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/malerate.value = value
 	var delta : int = value - input_handler.globalsettings.malechance
 	input_handler.globalsettings.malechance += delta
-	if $TabContainer/Gameplay/VBoxContainer/futarate.value < value:
-		$TabContainer/Gameplay/VBoxContainer/futarate.value = value
+	if $TabContainer/Gameplay/VBoxContainer/male_and_futa_rate.value < value:
+		$TabContainer/Gameplay/VBoxContainer/male_and_futa_rate.value = value
 	else:
                 # move the boundary shared with the futa range
 		input_handler.globalsettings.futachance -= delta
 	update_rate_text()
 
 func futa_rate_change(value):
-	$TabContainer/Gameplay/VBoxContainer/futarate.value = value
+	$TabContainer/Gameplay/VBoxContainer/male_and_futa_rate.value = value
 	if $TabContainer/Gameplay/VBoxContainer/malerate.value > value:
 		$TabContainer/Gameplay/VBoxContainer/malerate.value = value
 	var male = $TabContainer/Gameplay/VBoxContainer/malerate.value

--- a/src/scenes/Options.gd
+++ b/src/scenes/Options.gd
@@ -70,6 +70,10 @@ func open():
 
 	var male = input_handler.globalsettings.malechance
 	var futa = input_handler.globalsettings.futachance
+	if !input_handler.globalsettings.futa:
+		futa = 0
+	$TabContainer/Gameplay/VBoxContainer/futarate.visible = input_handler.globalsettings.futa
+
 	male_rate_change(male)
 	futa_rate_change(male + futa)
 	
@@ -118,11 +122,18 @@ func close():
 
 func update_rate_text() -> void:
 	var male : int = input_handler.globalsettings.malechance
-	var futa : int = input_handler.globalsettings.futachance
-	var female : int = 100 - (male + futa)
-	var text : String = "Male: %3d%%	 -  Futa: %3d%%	 -  Female: %3d%%" % [male, futa, female]
-	$TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
-	$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
+	var text : String = "<sex proportions go here>"
+
+	if input_handler.globalsettings.futa:
+		var futa : int = input_handler.globalsettings.futachance
+		var female : int = 100 - (male + futa)
+		text = "Male: %3d%%  -  Futa: %3d%%  -  Female: %3d%%" % [male, futa, female]
+		$TabContainer/Gameplay/VBoxContainer/futarate/Label.text = text
+		$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = ''
+	else:
+		var female : int = 100 - male
+		text = "Male: %3d%%  -  Female: %3d%%" % [male, female]
+		$TabContainer/Gameplay/VBoxContainer/malerate/Label.text = text
 
 func male_rate_change(value):
 	$TabContainer/Gameplay/VBoxContainer/malerate.value = value
@@ -131,7 +142,7 @@ func male_rate_change(value):
 	if $TabContainer/Gameplay/VBoxContainer/futarate.value < value:
 		$TabContainer/Gameplay/VBoxContainer/futarate.value = value
 	else:
-                # take (give) the change from (to) the futa range
+                # move the boundary shared with the futa range
 		input_handler.globalsettings.futachance -= delta
 	update_rate_text()
 

--- a/src/scenes/Options.tscn
+++ b/src/scenes/Options.tscn
@@ -134,10 +134,10 @@ __meta__ = {
 
 [node name="VBoxContainer" type="VBoxContainer" parent="TabContainer/Gameplay"]
 margin_left = 40.0
-margin_top = 90.0
+margin_top = 50.0
 margin_right = 576.0
 margin_bottom = 171.0
-custom_constants/separation = 31
+custom_constants/separation = 10
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -148,32 +148,20 @@ margin_bottom = 32.0
 value = 30.0
 ticks_on_borders = true
 
-[node name="Label" type="Label" parent="TabContainer/Gameplay/VBoxContainer/malerate"]
-margin_left = 11.0
-margin_top = -24.0
-margin_right = 476.0
-custom_fonts/font = ExtResource( 4 )
-custom_colors/font_color = Color( 0.976471, 0.882353, 0.505882, 1 )
-text = "MALERATE"
-align = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="futarate" type="HSlider" parent="TabContainer/Gameplay/VBoxContainer"]
-margin_top = 63.0
-margin_right = 536.0
-margin_bottom = 95.0
-ticks_on_borders = true
-
-[node name="Label" type="Label" parent="TabContainer/Gameplay/VBoxContainer/futarate"]
+[node name="SexRates" type="Label" parent="TabContainer/Gameplay/VBoxContainer"]
 margin_left = 11.0
 margin_top = -24.0
 margin_right = 482.0
 custom_fonts/font = ExtResource( 4 )
 custom_colors/font_color = Color( 0.976471, 0.882353, 0.505882, 1 )
-text = "FUTARATE"
+text = "<All the rates>"
 align = 1
+
+[node name="male_and_futa_rate" type="HSlider" parent="TabContainer/Gameplay/VBoxContainer"]
+margin_top = 63.0
+margin_right = 536.0
+margin_bottom = 95.0
+ticks_on_borders = true
 
 [node name="Audio" type="Tabs" parent="TabContainer"]
 visible = false


### PR DESCRIPTION
This PR changes the percentage sliders on the Options panel so that:
 1. 100% is always everybody and 0% is always nobody.
 2. The percentages always sum to 100%.
 3. Each percentage is clamped within 0% and 100%.
 4. If the 'futa' global setting is set to false then only one slider is shown; letting the player set the Male/Female percentages only.

(In the old code, only the male percentage was a fraction of the full population; the futa and female percentages were fractions of the remaining non-males.)

Practically, the two sliders cannot pass each other anymore. Instead, the actively moved slider pushes the other one along, like so:
![out](https://user-images.githubusercontent.com/72233028/98575254-3e08f280-22b9-11eb-83b7-3a47e5a83ec0.gif)

Things to revisit:

 - I've adjusted my UI changes to make them look good, but I'm sure that someone trained in these matters can do even better.

 - The space character used for padding isn't quite as wide as the digits, so the width of the full label changes slightly but visibly as digits come and go (it's visible in the GIF clip above, if you look carefully). One possible solution would be to find a white-space character that's _exactly_ as wide as a digit, and use that for padding. Another would be to put each percentage in its own label with its own alignment.