### PR TITLE
Godot 3.2.2 GDScript disallows variable shadowing.

### DIFF
--- a/gui_modules/Interaction/Scripts/InteractionMainModule.gd
+++ b/gui_modules/Interaction/Scripts/InteractionMainModule.gd
@@ -1193,16 +1193,16 @@ func startscene(scenescript, cont = false, pretext = ''):
 		if i.scene.has_method("givereffect"):
 			for member in i.givers:
 				effects = i.scene.givereffect(member)
-				for i in effects:
-					if i in ['sens','horny']:
-						effects[i] = effects[i]/2
+				for effect in effects:
+					if effect in ['sens','horny']:
+						effects[effect] = effects[effect]/2
 				member.actioneffect(effects, i)
 		if i.scene.has_method("takereffect"):
 			for member in i.takers:
 				effects = i.scene.takereffect(member)
-				for i in effects:
-					if i in ['sens','horny']:
-						effects[i] = effects[i]/2
+				for effect in effects:
+					if effect in ['sens','horny']:
+						effects[effect] = effects[effect]/2
 				member.actioneffect(effects, i)
 	
 	var request

--- a/gui_modules/Universal/Scripts/CombatV2Animated.gd
+++ b/gui_modules/Universal/Scripts/CombatV2Animated.gd
@@ -301,34 +301,34 @@ func victory():
 		var tchar = characters_pool.get_char_by_id(i)
 		rewardsdict.xp += tchar.get_stat('xpreward')
 		var loot = {}
-		for i in Enemydata.loottables[tchar.get_stat('loottable')]:
-			if i[0] == 'gold':
-				rewardsdict.gold += round(rand_range(i[1], i[2]))
-			elif Items.materiallist.has(i[0]):
+		for item in Enemydata.loottables[tchar.get_stat('loottable')]:
+			if item[0] == 'gold':
+				rewardsdict.gold += round(rand_range(item[1], item[2]))
+			elif Items.materiallist.has(item[0]):
 				var counter = 1
-				if i.size() > 2:
-					counter = i[2]
+				if item.size() > 2:
+					counter = item[2]
 				while counter > 0:
-					if randf() <= i[1]:
-						input_handler.AddOrIncrementDict(loot, {i[0] : 1})
+					if randf() <= item[1]:
+						input_handler.AddOrIncrementDict(loot, {item[0] : 1})
 					counter -= 1
 				input_handler.AddOrIncrementDict(rewardsdict.materials, loot)
-			elif Items.itemlist.has(i[0]):
-				var itemtemp = Items.itemlist[i[0]]
+			elif Items.itemlist.has(item[0]):
+				var itemtemp = Items.itemlist[item[0]]
 				var counter = 1
-				if i.size() > 2:
-					counter = i[2]
+				if item.size() > 2:
+					counter = item[2]
 				while counter > 0:
-					if randf() <= i[1]:
+					if randf() <= item[1]:
 						if itemtemp.type == 'usable':
 							var itemfound = false
 							for k in rewardsdict.items:
-								if k.itembase == i[0]:
+								if k.itembase == item[0]:
 									k.amount += 1
 									itemfound = true
 									break
 							if itemfound == false:
-								var newitem = globals.CreateUsableItem(i[0])
+								var newitem = globals.CreateUsableItem(item[0])
 								rewardsdict.items.append(newitem)
 					counter -= 1
 		
@@ -861,8 +861,8 @@ func buildenemygroup(enemygroup, enemy_stats_mod):
 		tchar.combatgroup = 'enemy'
 		tchar.position = i
 		
-		for i in ['hpmax', 'atk', 'matk', 'hitrate', 'armor', 'xpreward']:
-			tchar.mul_stat(i, enemy_stats_mod)
+		for stat in ['hpmax', 'atk', 'matk', 'hitrate', 'armor', 'xpreward']:
+			tchar.mul_stat(stat, enemy_stats_mod)
 		tchar.hp = tchar.get_stat("hpmax")
 		enemygroup[i] = characters_pool.add_char(tchar)
 		battlefield[int(i)] = enemygroup[i]

--- a/src/character/ch_skills.gd
+++ b/src/character/ch_skills.gd
@@ -334,8 +334,8 @@ func use_social_skill(s_code, target):
 				effect_text += " - Maxed"
 			if detail_tags.has("blocked") && stat == 'obedience':
 				effect_text += ' - Is in resist mode'
-			for i in bonusspeech:
-				effect_text += "\n\n{color=aqua|"+ h.get_short_name() + "} - {random_chat=0|"+ i +"}\n"
+			for j in bonusspeech:
+				effect_text += "\n\n{color=aqua|"+ h.get_short_name() + "} - {random_chat=0|"+ j +"}\n"
 	if target != null and target.skills.skills_received_today.has(s_code) == false: target.skills.skills_received_today.append(s_code)
 	
 	if template.has("dialogue_report"):

--- a/src/classes/ItemClass.gd
+++ b/src/classes/ItemClass.gd
@@ -124,8 +124,8 @@ func CreateGear(ItemName = '', dictparts = {}, bonus = {}):
 			var material = Items.materiallist[parts[i]]
 			var materialeffects = material['parts'][i].duplicate(true)
 			if itemtemplate.itemtype == 'armor':
-				for i in materialeffects:
-					materialeffects[i] = float(materialeffects[i]) / 2
+				for j in materialeffects:
+					materialeffects[j] = float(materialeffects[j]) / 2
 			materials.append(material.code)
 			input_handler.AddOrIncrementDict(parteffectdict, materialeffects)
 #		if parteffectdict.has('durabilitymod'):

--- a/src/core/globals.gd
+++ b/src/core/globals.gd
@@ -947,24 +947,24 @@ func makerandomgroup(enemygroup):
 			
 			if true:
 				#smart way
-				for i in combatparty:
-					if combatparty[i] != null:
+				for j in combatparty:
+					if combatparty[j] != null:
 						continue
 					var aiposition = unit.ai_position[randi()%unit.ai_position.size()]
-					if aiposition == 'melee' && i in [1,2,3]:
-						temparray.append(i)
-					if aiposition == 'ranged' && i in [4,5,6]:
-						temparray.append(i)
+					if aiposition == 'melee' && j in [1,2,3]:
+						temparray.append(j)
+					if aiposition == 'ranged' && j in [4,5,6]:
+						temparray.append(j)
 				
 				if temparray.size() <= 0:
-					for i in combatparty:
-						if combatparty[i] == null:
-							temparray.append(i)
+					for j in combatparty:
+						if combatparty[j] == null:
+							temparray.append(j)
 			else:
 				#stupid way
-				for i in combatparty:
-					if combatparty[i] != null:
-						temparray.append(i)
+				for j in combatparty:
+					if combatparty[j] != null:
+						temparray.append(j)
 			
 			if temparray.size() > 0:
 				combatparty[temparray[randi()%temparray.size()]] = i.units

--- a/src/core/modding_core.gd
+++ b/src/core/modding_core.gd
@@ -55,10 +55,10 @@ func get_mods_list():
 	f.close()
 	mods_list = parse_json(tres)
 	check_avail()
-	for f in mods_list:
+	for mod in mods_list:
 		var mconf := ConfigFile.new()
-		mconf.load(f.path)
-		f.config = mconf
+		mconf.load(mod.path)
+		mod.config = mconf
 
 func save_mod_list():
 	check_avail()

--- a/src/core/world_gen.gd
+++ b/src/core/world_gen.gd
@@ -90,10 +90,10 @@ func update_area_shop(area):
 					var item = Items.itemlist[data.items[randi()%data.items.size()]]
 					if item.has('parts'):
 						var parts = {}
-						for i in item.parts:
+						for part in item.parts:
 							var tiers = []
-							for i in area.material_tiers:
-								tiers.append([i, area.material_tiers[i]])
+							for tier in area.material_tiers:
+								tiers.append([tier, area.material_tiers[tier]])
 							var materialtier = input_handler.weightedrandom(tiers)
 							var materialarray = []
 							for k in Items.materials_by_tiers[materialtier]:
@@ -101,10 +101,10 @@ func update_area_shop(area):
 									materialarray.append(k)
 							if materialarray.size() == 0:
 								for k in Items.materiallist.values():
-									if k.has('parts') && k.parts.has(i):
+									if k.has('parts') && k.parts.has(part):
 										materialarray.append([k.code, 1.0/k.price])
 								materialarray = [input_handler.weightedrandom(materialarray)]
-							parts[i] = materialarray[randi()%materialarray.size()]
+							parts[part] = materialarray[randi()%materialarray.size()]
 						area.shop[item.code] = parts
 					else:
 						if area.shop.has(item.code):

--- a/src/scenes/SaveLoadPanel_v2.gd
+++ b/src/scenes/SaveLoadPanel_v2.gd
@@ -29,8 +29,8 @@ func SavePanelOpen():
 			config.load(i)
 			var details = config.get_section_keys('details')
 			savedata[savename] = {}
-			for i in details:
-				savedata[savename][i] = config.get_value("details", i, null)
+			for detail in details:
+				savedata[savename][detail] = config.get_value("details", detail, null)
 		if i.ends_with('.sav') == false:
 			continue
 		var newbutton = input_handler.DuplicateContainerTemplate($ScrollContainer/VBoxContainer)
@@ -55,8 +55,8 @@ func LoadPanelOpen():
 			config.load(i)
 			var details = config.get_section_keys('details')
 			savedata[savename] = {}
-			for i in details:
-				savedata[savename][i] = config.get_value("details", i, null)
+			for detail in details:
+				savedata[savename][detail] = config.get_value("details", detail, null)
 		if i.ends_with('.sav') == false:
 			continue
 		var newbutton = input_handler.DuplicateContainerTemplate($ScrollContainer/VBoxContainer)

--- a/src/sexdescriptions.gd
+++ b/src/sexdescriptions.gd
@@ -850,13 +850,13 @@ func partner(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#assures correct return values
 	if marray1 == []:
 		if marray2 == []:
@@ -953,26 +953,26 @@ func partners(group):
 				boygirl = "girl's" if group.size() == 1 else "girls'"
 		array2 += [boygirl]
 		#race
-		for i in racenames:
-			if i == mp.race:
-				array2 += [racenames[i].single + ' ' + boygirl]
+		for j in racenames:
+			if j == mp.race:
+				array2 += [racenames[j].single + ' ' + boygirl]
 				if group.size() >= 2:
-					array2 += [racenames[i].pluralpos]
+					array2 += [racenames[j].pluralpos]
 				else:
-					array2 += [racenames[i].singlepos]
+					array2 += [racenames[j].singlepos]
 		#for multiple people, only incude shared
 		if marray1 == null:
 			marray1 = array1
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#assures correct return values
 	if marray1 == []:
 		if marray2 == []:
@@ -1039,13 +1039,13 @@ func body(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.5 || marray1 == []:
 		return getrandomfromarray(marray2)
@@ -1096,13 +1096,13 @@ func penis(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.3 || marray1 == []:
 		return getrandomfromarray(marray2)
@@ -1150,13 +1150,13 @@ func pussy(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.3 || marray1 == []:
 		return getrandomfromarray(marray2)
@@ -1244,13 +1244,13 @@ func ass(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.3 || marray1 == []:
 		return getrandomfromarray(marray2)
@@ -1309,13 +1309,13 @@ func hips(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.5 || marray1 == []:
 		return getrandomfromarray(marray2)
@@ -1387,13 +1387,13 @@ func tits(group):
 			marray2 = array2
 		else:
 			tarray = [] + marray1
-			for i in tarray:
-				if not array1.has(i):
-					marray1.erase(i)
+			for j in tarray:
+				if not array1.has(j):
+					marray1.erase(j)
 			tarray = [] + marray2
-			for i in tarray:
-				if not array2.has(i):
-					marray2.erase(i)
+			for j in tarray:
+				if not array2.has(j):
+					marray2.erase(j)
 	#30% of time do not use descriptors
 	if  randf() < 0.3 || marray1 == []:
 		return getrandomfromarray(marray2)


### PR DESCRIPTION
In Godot 3.2.1, GDScript were fine with constructs like:

```gdscript
  for i in range:
      #...
      for i in other_range:
         #...
```
unhelpful and confusing as it is. In Godot 3.2.2, the GDScript parser
raises an error when it sees this construct.