### PR TITLE
adjust elder gryphon animation

### DIFF
--- a/assets/data/skilldata/bosses/elder_gryphon.gd
+++ b/assets/data/skilldata/bosses/elder_gryphon.gd
@@ -180,7 +180,7 @@ var skills = {
 		aipatterns = ['attack'],
 		allowedtargets = ['enemy'],
 		value = [['tornado',null], 3],
-		sfx = [{code = 'wind_blade', target = 'target', period = 'predamage'}], 
+		sfx = [{code = 'wind_blade', target = 'target', period = 'predamage', force_flip = true}], 
 		sounddata = {initiate = null, strike = 'spell_break', hit = null},
 	},
 	downburst_gust = {
@@ -207,7 +207,7 @@ var skills = {
 		target_number = 'wave',
 		target_range = 'any',
 		damage_type = 'air',
-		sfx = [{code = 'wind_wall', target = 'caster_line', period = 'windup',force_flip = true}, {code = 'wind_blade', target = 'target', period = 'predamage'}], 
+		sfx = [{code = 'wind_blade', target = 'target', period = 'predamage'}], 
 		sounddata = {initiate = null, strike = 'spell_lightning', hit = null},
 		value = 1.2,
 	},

--- a/localization/en/main.gd
+++ b/localization/en/main.gd
@@ -4519,9 +4519,10 @@ Can be removed by being frozen.""",
 Prepare to receive a lot of damage.""",
 	EFFECTNAME_HEIGHT_BEYOND_MORTAL_REACH = 'Height Beyond Mortal Reach',
 	EFFECT_HEIGHT_BEYOND_MORTAL_REACH = """Always evade melee attacks.
-50% chance to evade spells. Reduce ranged damage taken by 40%
+50% chance to evade spells. Reduce ranged damage taken by 40%.
 +125 Evasion and Earth resist is set to 100.
-Can use skill even under immobilizing effects.""",
+Can use skill even under immobilizing effects.
+Will use [Comet Dive] skill once expired.""",
 	EFFECTNAME_CATASTROPHIC_MOMENTUM = 'Catastrophic Momentum',
 	EFFECT_CATASTROPHIC_MOMENTUM = """+50% ATK and +150 Hit rate per stack (Max 2 stack).
 At 2 stack: Comet Dive now cause a damaging shockwave which can be resist by Stonewall and Earth Shield.


### PR DESCRIPTION
- remove wind_wall since it can't be flip and also make the wind_blade sfx of the Tornado skill flipped
- clarify in the Height Beyond Mortal Reach Effect that [Comet Dive] will be use once it's expired.