### PR TITLE
Prevent Counter attack trigger another counter attack

### DIFF
--- a/assets/data/skilldata/bosses/aire.gd
+++ b/assets/data/skilldata/bosses/aire.gd
@@ -245,6 +245,7 @@ var effects = {
 		req_skill = true,
 		conditions = [
 			{type = 'skill', value = ['tags', 'has', 'damage'] },
+			{type = 'skill', value = ['mode', 'eq', variables.SKILL_BASE]},
 			{type = 'target', value = [{code = 'stat', stat = 'combatgroup', value = 'enemy', operant = 'eq'}] },
 			{type = 'target', value = [{code = 'trait', trait = 'aire_overwatch_assignment', check = false}] },
 			{type = 'caster', value = [{code = 'stat', stat = 'hp', operant = 'gt', value = 0}]},

--- a/assets/data/skilldata/bosses/ramont.gd
+++ b/assets/data/skilldata/bosses/ramont.gd
@@ -219,6 +219,7 @@ var effects = {
 			{type = 'skill', value = ['tags', 'has', 'damage'] },
 			{type = 'skill', value = ['target_range', 'eq', 'melee']},
 			{type = 'skill', value = ['ability_type', 'eq', 'skill']},
+			{type = 'skill', value = ['mode', 'eq', variables.SKILL_BASE]},
 		],
 		args = {
 			skill = {obj = 'skill', func = 'eq'},


### PR DESCRIPTION
slap `{type = 'skill', value = ['mode', 'eq', variables.SKILL_BASE]},` on Aire and Ramont effect to prevent their counter attack from being triggered by player counter attack.