### PR TITLE
leon summon interaction fix

### DIFF
--- a/assets/data/Effects.gd
+++ b/assets/data/Effects.gd
@@ -1,7 +1,7 @@
 extends Node
 
 
-var effect_nolog = ['commander', 'atkpass', 'atkpass_remove', 'hide', 'default', 'warlock', 'manasiphon', 'thorns', 'vampirism', 'ench_commander', 'spell_mastery', 'flight_upkeep', 'max_stats'] #2add more
+var effect_nolog = ['commander', 'atkpass', 'atkpass_remove', 'hide', 'default', 'warlock', 'manasiphon', 'thorns', 'vampirism', 'ench_commander', 'spell_mastery', 'flight_upkeep', 'max_stats','sanguine_instinct_listener'] #2add more
 #to fix EFFECT TAGS TO TEMPLATE,
 #'positive'/'negative' - the widest classification (to most global cleaning like bard2 skill effect)
 #'buff'/'debuff' - additional markings for common effect removal effects (like purge) (and maybe add two more for a state effects)

--- a/assets/data/skilldata/bosses/leon.gd
+++ b/assets/data/skilldata/bosses/leon.gd
@@ -11,7 +11,7 @@ var skills = {
 		tags = ['aoe', 'debuff','instant','noreduce', 'noevade','passive'],
 		reqs = [],
 		targetreqs = [],
-		effects = [Effectdata.rebuild_template({effect = 'sanguine_instinct_listener', duration = 1})], 
+		effects = ['sanguine_instinct_apply_1'], 
 		cost = {},
 		charges = 0,
 		combatcooldown = 0,
@@ -55,31 +55,6 @@ var skills = {
 		sounddata = {initiate = null, strike = 'spell2', hit = null},
 		value = [['0']],
 		damagestat = 'no_stat'
-	},
-	scent_of_blood = {
-		code = 'scent_of_blood',
-		descript = '',
-		icon =  "res://assets/images/iconsskills/icon_blood_explosion.png",
-		type = 'auto', 
-		ability_type = 'spell',
-		tags = ['aoe', 'debuff','instant','noreduce', 'noevade','passive'],
-		reqs = [],
-		targetreqs = [],
-		effects = [Effectdata.rebuild_template({effect = 'bloodthrist'})], 
-		cost = {},
-		charges = 0,
-		combatcooldown = 0,
-		cooldown = 0,
-		catalysts = {},
-		target = 'self',
-		target_number = 'nontarget_group',
-		target_range = 'any',
-		damage_type = 'weapon',
-		sfx = [], 
-		sounddata = {initiate = null, strike = null, hit = null, hittype = null},
-		value = [['0']],
-		damagestat = ['no_stat'],
-		critchance = 0,
 	},
 	#actual move
 	lion_swipe = {
@@ -375,34 +350,44 @@ var effects = {
 			},
 		],
 	},
-	sanguine_instinct_listener = {
-		type = 'temp_s',
-		target = 'target',
+	sanguine_instinct_apply_1 = {
+		type = 'trigger',
+		trigger = [variables.TR_POSTDAMAGE],
+		req_skill = true,
+		conditions = [
+			{type = 'target', value = [{code = 'has_status', status = 'sanguine_instinct_listener', check = false}]},
+		],
 		duration = 1,
-		tick_event = [variables.TR_TURN_S,],
-		rem_event = [variables.TR_COMBAT_F],
-		conditions = [],
-		buffs = [],
-		statchanges = {},
+		args = {target = {obj = 'target', func = 'eq'},},
+		sub_effects = ['sanguine_instinct_listener']
+	},
+	sanguine_instinct_listener = {
+		type = 'temp_global',
+		tags = ['duration_none', 'sanguine_instinct_listener'],
+		target = 'target',
+		req_skill = true,
+		name = '',
+		timers = [
+			{events = variables.TR_COMBAT_F, objects = [], timer = 1},
+			{events = variables.TR_DEATH, objects = 'caster', timer = 1},
+		],
+		sub_effects = ['sanguine_instinct_listen',],
+	},
+	sanguine_instinct_listen = {
+		type = 'trigger',
+		trigger = [variables.TR_TURN_F],
+		req_skill = false,
+		conditions = [
+			{type = 'owner', value = [{code = 'has_status', status = 'bleed', check = true}]},
+		],
+		args = {skill = {obj = 'owner', func = 'eq'}, smeller = {obj = 'parent', func = 'arg', arg = 'caster'}},
 		sub_effects = [
 			{
-				type = 'trigger',
-				trigger = [variables.TR_TURN_F],
-				req_skill = false,
-				conditions = [
-					{type = 'owner', value = [{code = 'has_status', status = 'bleed', check = true}]},
-				],
-				args = {skill = {obj = 'owner', func = 'eq'},},
-				sub_effects = [
-					{
-						type = 'oneshot',
-						target = 'owner',
-						atomic = [{type = 'use_combat_skill', skill = 'scent_of_blood'}],
-					},
-				]
+				type = 'oneshot',
+				target = 'smeller',
+				atomic = [{type = 'effect', value = 'bloodthrist'}],
 			},
-		],
-		tags = ['sanguine_instinct_listener'],
+		]
 	},
 	sanguine_instinct_self = {
 		type = 'trigger',


### PR DESCRIPTION
Hopefully fix the the issue where the game soft-lock if summon were to die from DoT effect in Leon fight. 

Suspect to cause due to the fact that dead summon is complete removed from the fight, thus, unable to use scent_of_blood. 

Changing the code behind sanguine instinct by using temp_global magic instead make the bug no longer appear from my testing.